### PR TITLE
Add a search path to Opalstack's Python installation.

### DIFF
--- a/bin/_py-utils
+++ b/bin/_py-utils
@@ -2,7 +2,7 @@ LOCAL_PYTHON_DIR=$HOME/opt
 
 
 function pyAvailableVersions() {
-  (ls /usr/bin/python*; ls $LOCAL_PYTHON_DIR/bin/python*) | grep -oP 'python\K[0-9]+\.[0-9]+' | sort -V | uniq
+  (ls /usr/bin/python*; ls $LOCAL_PYTHON_DIR/bin/python*; ls /usr/local/bin/python*) | grep -oP 'python\K[0-9]+\.[0-9]+' | sort -V | uniq
 }
 
 


### PR DESCRIPTION
Due to a lack of OpenSSL 1.1.1, the command "py-install-version 3.10" would fail when attempting to build Python 3.10. @defulmere [mentioned](https://community.opalstack.com/d/1016-failed-to-install-python-3106-with-user-installed-openssl/2) that Python 3.10 (and also 3.11) is installed on a different path. Instead of building and installing OpenSSL 1.1.1, using Opalstack-installed Python is a much more efficient solution.

A path to the Opalstack-installed Python is added to the function that checks for available Python with this patch.